### PR TITLE
fix p2p selection statement in getWaveformSNR()

### DIFF
--- a/src/FFTtools.cxx
+++ b/src/FFTtools.cxx
@@ -2116,26 +2116,26 @@ Double_t FFTtools::getWaveformSNR(const TGraph *gr,Double_t &peakToPeak,Double_t
     y=yVals[i];
     if(i>0){
       if(y<yVals[i-1] && trending==0){
-	if(TMath::Abs(y-yVals[firstBin]>p2p)){
+	if(TMath::Abs(y-yVals[firstBin])>p2p){
 	  p2p=TMath::Abs(y-yVals[firstBin]);
 	}
       }
       else if(y<yVals[i-1] && (trending==1 || trending==2)){
 	trending=0;
 	firstBin=i-1;
-	if(TMath::Abs(y-yVals[firstBin]>p2p)){
+	if(TMath::Abs(y-yVals[firstBin])>p2p){
 	  p2p=TMath::Abs(y-yVals[firstBin]);
 	}
       }
       else if(y>yVals[i-1] && (trending==0 || trending==2)){
 	trending=1;
 	firstBin=i-1;
-	if(TMath::Abs(y-yVals[firstBin]>p2p)){
+	if(TMath::Abs(y-yVals[firstBin])>p2p){
 	  p2p=TMath::Abs(y-yVals[firstBin]);
 	}
       }
       else if(y>yVals[i-1] && trending==1){
-	if(TMath::Abs(y-yVals[firstBin]>p2p)){
+	if(TMath::Abs(y-yVals[firstBin])>p2p){
 	  p2p=TMath::Abs(y-yVals[firstBin]);
 	}
       }


### PR DESCRIPTION
By following this line : `if(TMath::Abs(y-yVals[firstBin]>p2p)){ `in `getWaveformSNR()`,
That line is checking whether the new p2p value is bigger than the previous p2p value or not.
But it looks like it is comparing the two values by the inside of `TMath::Abs()`
In this case, the new p2p value can be still in a negative state during the comparison.
Basically, it is ignoring all 'negative slope or downgoing p2p(+ to -)' results(if it is not intended).
In order to compare them in the right way, I think it should be `if ( TMath::Abs(y - yVals[firstBin]) > p2p ){`.