### PR TITLE
SineSubtract updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,12 @@ list(APPEND CMAKE_PREFIX_PATH $ENV{ROOTSYS})
 #---Locate the ROOT package and defines a number of variables (e.g. ROOT_INCLUDE_DIRS)
 find_package(ROOT REQUIRED COMPONENTS MathMore MathCore RIO Hist Tree Net
   Minuit Spectrum OPTIONAL_COMPONENTS Minuit2)
-find_package(FFTW REQUIRED)
+if(FFTW_INCLUDES)
+  find_package(FFTW REQUIRED)
+else()
+  set(FFTW_LIBRARIES "$ENV{FFTWSYS}/lib/libfftw3.so.3.6.9")
+  set(FFTW_INCLUDES "$ENV{FFTWSYS}/include")
+endif()
 
 #---Define useful ROOT functions and macros (e.g. ROOT_GENERATE_DICTIONARY)
 

--- a/include/SineSubtract.h
+++ b/include/SineSubtract.h
@@ -153,9 +153,9 @@ namespace FFTtools
 
 
 
-       SineFitterLimits(double maxA_relative_to_guess_ = 4, double minA_relative_to_guess_ = 0.25, 
+       SineFitterLimits(double maxA_relative_to_guess_ = 1, double minA_relative_to_guess_ = 0.0625, 
                         double max_n_df_relative_to_guess_ = 1, double phase_start_error_ = TMath::Pi() / 16, 
-                        double amp_start_error_ = 0.1, double freq_start_error_  = 0.1) : 
+                        double amp_start_error_ = 0.025, double freq_start_error_  = 0.1) : 
                                maxA_relative_to_guess(maxA_relative_to_guess_), 
                                minA_relative_to_guess(minA_relative_to_guess_),
                                max_n_df_relative_to_guess(max_n_df_relative_to_guess_) , 

--- a/include/SineSubtract.h
+++ b/include/SineSubtract.h
@@ -650,7 +650,7 @@ namespace FFTtools
         /** Get array of the sequence of powers vs. iteration 
          * lighter version of getPowerSequence()
          **/
-        const double * getPowers() const {return &r.powers[0];}
+        const double * getPowers() const { return &r.powers[0]; }
 
         /** Get array of fit phases for the ith trace */
         const double * getPhases(int g) const { return &r.phases[g][0]; }

--- a/include/SineSubtract.h
+++ b/include/SineSubtract.h
@@ -647,6 +647,11 @@ namespace FFTtools
         /* Return the number of traces fit for */
         int getNGraphs() const { return r.phases.size(); } 
 
+        /** Get array of the sequence of powers vs. iteration 
+         * lighter version of getPowerSequence()
+         **/
+        const double * getPowers() const {return &r.powers[0];}
+
         /** Get array of fit phases for the ith trace */
         const double * getPhases(int g) const { return &r.phases[g][0]; }
 

--- a/src/SineSubtract.cxx
+++ b/src/SineSubtract.cxx
@@ -1151,7 +1151,7 @@ void FFTtools::SineSubtract::subtractCW(int ntraces, TGraph ** g, double dt, con
 
         for (int i = 0; i < spectrum_N; i++)
         {
-          power_spectra[ti]->GetY()[i] = the_fft[i].getAbsSq() / NuseMax / 16 / pad_scale_factor; //why was this factor of 16 here? 
+          power_spectra[ti]->GetY()[i] = the_fft[i].getAbsSq() / NuseMax / pad_scale_factor; 
           if (i > 0 && i <spectrum_N-1) power_spectra[ti]->GetY()[i] *=2; 
           fft_phases[ti]->GetY()[i] = the_fft[i].getPhase(); 
           power_spectra[ti]->GetX()[i] = df *i; 


### PR DESCRIPTION
1. FFTW linking

In the ara cvmfs environment, `FFTW_INCLUDES` is not defined. It causes errors during the compilation.
I put the 'If' condition that if `FFTW_INCLUDES` is not defined, it will define `FFTW_INCLUDES` and `FFTW_LIBRARIES` from the `FFTWSYS` path.
Hope this is an acceptable modification for all the compilation conditions.

2. Removal of 16

[16](https://github.com/nichol77/libRootFftwWrapper/blob/bb945e6b6d5afc82c75b6cb21dc8d1ceb17446c0/src/SineSubtract.cxx#L1154) is altering the magnitude of `power_spectra` values.
And `SineSubtract.cxx` is using the same `power_spectra` as an [initial guess](https://github.com/nichol77/libRootFftwWrapper/blob/bb945e6b6d5afc82c75b6cb21dc8d1ceb17446c0/src/SineSubtract.cxx#L1239) of fit.
Since several [Set~LimitedVariable](https://github.com/nichol77/libRootFftwWrapper/blob/bb945e6b6d5afc82c75b6cb21dc8d1ceb17446c0/src/SineSubtract.cxx#L787) functions (line 787 ~ 803) in the [dofit](https://github.com/nichol77/libRootFftwWrapper/blob/bb945e6b6d5afc82c75b6cb21dc8d1ceb17446c0/src/SineSubtract.cxx#L722) are using [amp](https://github.com/nichol77/libRootFftwWrapper/blob/bb945e6b6d5afc82c75b6cb21dc8d1ceb17446c0/src/SineSubtract.cxx#L186) ((`power_spectra`)^(1/2)) values on the first attempt of [Minimize()](https://github.com/nichol77/libRootFftwWrapper/blob/bb945e6b6d5afc82c75b6cb21dc8d1ceb17446c0/src/SineSubtract.cxx#L818), It might give wrong minimization results to users

3. Modification of amplitude fit boundaries

Because of `16`, the actual amplitude that the package is using for setting initial guesses and fit boundaries is `amp/4`.
Since, upper, lower, and damp values ([Set~LimitedVariable](https://github.com/nichol77/libRootFftwWrapper/blob/bb945e6b6d5afc82c75b6cb21dc8d1ceb17446c0/src/SineSubtract.cxx#L787)) in the original code are like below.
upper: `amp[0]*limits.maxA_relative_to_guess` -> `amp/4` * 4 = amp
lower: `amp[0]*limits.minA_relative_to_guess` -> `amp/4` * 0.25 = amp/16
damp: `limits.amp_start_error* amp[0]` - > 0.1 *  `amp/4` = amp/40

In order to preserve this condition, I changed `minA_relative_to_guess`, `maxA_relative_to_guess`, and `amp_start_error` like below.
upper: `amp[0]*limits.maxA_relative_to_guess` -> `amp` * **1** = amp
lower: `amp[0]*limits.minA_relative_to_guess` -> `amp` * **0.0625** = amp/16
damp: `limits.amp_start_error* amp[0]` - >  **0.025** * `amp` = amp/40
This changes might need to be verified in the future

4. Added `getPowers()` function in SineSubtract class

It is basically same as `getPowerSequence()` function. If I use the `getPowerSequence()` function with python language, somehow it is eat up memory and does not release it (possibly I'm just ignorant about the relation between python and C++ )
So, I added a 'lighter version'. Let me know if this is redundant

Below two plots are comparisons before/after this update
Navy is the frequency spectrum of the original waveform.
Orange is the frequency spectrum of the waveform after going through the `SineSubtract` package.
The setting of the SineSubtract was 
`max_iter_without_reduction` = 3
`min_power_reduction` = 0.01
`dt` = 0.5 ns
`min` = 0.125 GHz in `setFreqLimits()`
`max` = 0.85 GHz in `setFreqLimits()`
Almost identical...

Before
![FFT_A2_R4434_Evt84329_Ch11_CW](https://user-images.githubusercontent.com/53809378/169635238-267cdfad-3b96-468c-b48a-d129c856da01.png)

After
![FFT_A2_R4434_Evt84329_Ch11_CW](https://user-images.githubusercontent.com/53809378/169635245-32fc4504-d908-4228-bfd6-433bce07651c.png)

Hope this makes sense!


