### PR TITLE
Cmake Version bump

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # CMakeLists.txt for libRootFftwWrapper.
 # 
-cmake_minimum_required(VERSION 2.8.10)
+cmake_minimum_required(VERSION 3.5)
 
 project(RootFftwWrapper)
 set(libname "RootFftwWrapper")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # CMakeLists.txt for libRootFftwWrapper.
 # 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 2.8.10...1000)
 
 project(RootFftwWrapper)
 set(libname "RootFftwWrapper")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # CMakeLists.txt for libRootFftwWrapper.
 # 
-cmake_minimum_required(VERSION 2.8.10...1000)
+cmake_minimum_required(VERSION 2.8.10...1000.0)
 
 project(RootFftwWrapper)
 set(libname "RootFftwWrapper")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # CMakeLists.txt for libRootFftwWrapper.
 # 
-cmake_minimum_required(VERSION 2.8.10...1000.0)
+cmake_minimum_required(VERSION 2.8.10...4.1)
 
 project(RootFftwWrapper)
 set(libname "RootFftwWrapper")


### PR DESCRIPTION
New cmake (>4) no longer support older versions. See the release notes: https://cmake.org/cmake/help/latest/release/4.0.html. 

"Compatibility with versions of CMake older than 3.5 has been removed. Calls to cmake_minimum_required() or cmake_policy() that set the policy version to an older value now issue an error. Note that calls to those commands can still support older versions of CMake by using their VERSION arguments' <min>...<max> syntax. This requires only the <min> version of CMake, but when running a newer version, sets policies up to the <max> version."

Also, hopefully no one is using cmake that old.